### PR TITLE
Add minimal sphinx example

### DIFF
--- a/ci_demo/functionality.py
+++ b/ci_demo/functionality.py
@@ -5,10 +5,15 @@ def greet(name=""):
     """
     A function that takes a name and returns a greeting.
 
-    :param name: the name to greet, default to ""
-    :type name: str
-    :return: the greeting
-    :rtype: str
+    Parameters
+    ----------
+    name : str, optional
+        The name to greet (default is "")
+
+    Returns
+    -------
+    str
+        The greeting
     """
     return "Hello " + name
 
@@ -17,10 +22,15 @@ def minimum(*args):
     """
     A function taking some arguments and returning the minimum number among the arguments.
 
-    :param args: numbers from which to return the minimum
-    :type args: int,float
-    :return: the minimum
-    :rtype: int,float
+    Parameters
+    ----------
+    args : int, float
+        The numbers from which to return the minimum
+
+    Returns
+    -------
+    int,float
+        The minimum
     """
     if not any([isinstance(arg, numbers.Real) for arg in args]):
         return

--- a/ci_demo/functionality.py
+++ b/ci_demo/functionality.py
@@ -5,8 +5,10 @@ def greet(name=""):
     """
     A function that takes a name and returns a greeting.
 
-    :param name: the name to greet
+    :param name: the name to greet, default to ""
+    :type name: str
     :return: the greeting
+    :rtype: str
     """
     return "Hello " + name
 
@@ -15,8 +17,10 @@ def minimum(*args):
     """
     A function taking some arguments and returning the minimum number among the arguments.
 
-    :param args: the arguments
+    :param args: numbers from which to return the minimum
+    :type args: int,float
     :return: the minimum
+    :rtype: int,float
     """
     if not any([isinstance(arg, numbers.Real) for arg in args]):
         return

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,8 +27,7 @@ author = 'Fergus Cooper'
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = [
-]
+extensions = ['sphinx.ext.autodoc']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,52 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'CI demo'
+copyright = '2020, Fergus Cooper'
+author = 'Fergus Cooper'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'alabaster'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,7 @@ author = 'Fergus Cooper'
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx.ext.autodoc']
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.napoleon']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,20 @@
+.. CI demo documentation master file, created by
+   sphinx-quickstart on Tue Jul 21 17:19:37 2020.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to CI demo's documentation!
+===================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,6 +10,10 @@ Welcome to CI demo's documentation!
    :maxdepth: 2
    :caption: Contents:
 
+   install
+   quickstart
+   reference
+
 
 
 Indices and tables

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -1,0 +1,4 @@
+Installation
+============
+
+Make sure your users know how to install your software!

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -1,0 +1,7 @@
+Getting started
+===============
+
+It's good practice to provide a brief, head-first "getting started" guide... for
+impatient users to get a feel of the features of your package/scripts.
+
+They can always consult the reference at a later stage if they want to go deeper.

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -1,0 +1,2 @@
+functionality module reference
+==============================

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -1,2 +1,6 @@
 functionality module reference
 ==============================
+
+.. autofunction:: ci_demo.functionality.greet
+
+.. autofunction:: ci_demo.functionality.minimum

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
 
     extras_require={
         'docs': [
-            'mkdocs'
+            'sphinx'
         ],
         'dev': [
             'flake8',


### PR DESCRIPTION
This adds a minimal sphinx setup under `docs/`. 

API documentation is generated from docstrings using [sphinx.ext.autodoc](https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#module-sphinx.ext.autodoc).

[f90b423](https://github.com/OxfordRSE/ci_demo/commit/f90b42393f5dc61317a698273e5054726c9c8283) illustrates original rST docstrings format.

[a700940](https://github.com/OxfordRSE/ci_demo/commit/a700940f6b14e33fe98897680222432138ce44d7) illustrates the more readable Numpy/Scipy format
